### PR TITLE
feat: add DeepSeek recipe client with schema validation

### DIFF
--- a/llm_client.py
+++ b/llm_client.py
@@ -1,15 +1,21 @@
-"""Обёртка для обращения к LLM и генерации рецептов."""
+"""Клиент LLM для генерации рецептов с валидированным JSON-ответом."""
 
+from __future__ import annotations
+
+import json
 from pathlib import Path
+from typing import List
 
 from dotenv import load_dotenv
-from openai import OpenAI
+from openai import DeepSeek
+from pydantic import BaseModel, ValidationError
 
 load_dotenv()  # загрузка переменных окружения из .env
 
 
 def _load_prompt(name: str) -> str:
     """Читает текст подсказки из каталога prompts."""
+
     path = Path("prompts") / name
     return path.read_text(encoding="utf-8")
 
@@ -17,17 +23,130 @@ def _load_prompt(name: str) -> str:
 SYSTEM_PROMPT = _load_prompt("recipe_system.md")
 USER_TEMPLATE = _load_prompt("recipe_user_template.md")
 
-_client = OpenAI()  # инициализация клиента с API-ключом из окружения
+
+class Nutrition(BaseModel):
+    """Пищевая ценность рецепта."""
+
+    calories: int
+    protein: float
+    fat: float
+    carbs: float
 
 
-def generate_recipe(ingredients: str) -> str:
-    """Формирует рецепт на основе списка ингредиентов."""
-    prompt = USER_TEMPLATE.format(ingredients=ingredients)
-    response = _client.chat.completions.create(
-        model="gpt-3.5-turbo",
-        messages=[
+class Recipe(BaseModel):
+    """Модель рецепта, которую возвращает LLM."""
+
+    name: str
+    ingredients: List[str]
+    steps: List[str]
+    nutrition: Nutrition
+    cholesterol_mg: int
+    glycemic_index: int
+    approx: bool
+
+
+class RecipeLLM:
+    """Обёртка над DeepSeek для генерации рецептов."""
+
+    def __init__(self, model: str = "gpt-4o-mini", temperature: float = 0.7) -> None:
+        self._client = DeepSeek()
+        self._model = model
+        self._temperature = temperature
+
+        self._schema = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "recipe",
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "ingredients": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        "steps": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        "nutrition": {
+                            "type": "object",
+                            "properties": {
+                                "calories": {"type": "integer"},
+                                "protein": {"type": "number"},
+                                "fat": {"type": "number"},
+                                "carbs": {"type": "number"},
+                            },
+                            "required": [
+                                "calories",
+                                "protein",
+                                "fat",
+                                "carbs",
+                            ],
+                        },
+                        "cholesterol_mg": {"type": "integer"},
+                        "glycemic_index": {"type": "integer"},
+                        "approx": {"type": "boolean"},
+                    },
+                    "required": [
+                        "name",
+                        "ingredients",
+                        "steps",
+                        "nutrition",
+                        "cholesterol_mg",
+                        "glycemic_index",
+                        "approx",
+                    ],
+                },
+            },
+        }
+
+    def generate_recipe(self, ingredients: str) -> Recipe:
+        """Формирует рецепт на основе списка ингредиентов."""
+
+        prompt = USER_TEMPLATE.format(ingredients=ingredients)
+        messages = [
             {"role": "system", "content": SYSTEM_PROMPT},
             {"role": "user", "content": prompt},
-        ],
-    )
-    return response.choices[0].message.content.strip()
+        ]
+
+        # Две попытки получения корректного JSON от модели
+        for _ in range(2):
+            try:
+                response = self._client.chat.completions.create(
+                    model=self._model,
+                    messages=messages,
+                    temperature=self._temperature,
+                    response_format=self._schema,
+                )
+            except Exception:
+                # Повторный запрос без structured outputs
+                messages.append(
+                    {
+                        "role": "system",
+                        "content": "Всегда отвечай строго в JSON по оговорённой схеме.",
+                    }
+                )
+                response = self._client.chat.completions.create(
+                    model=self._model,
+                    messages=messages,
+                    temperature=self._temperature,
+                )
+
+            content = response.choices[0].message["content"]
+            try:
+                data = json.loads(content)
+                return Recipe.model_validate(data)
+            except (json.JSONDecodeError, ValidationError):
+                messages.append({"role": "assistant", "content": content})
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": "Верни корректный JSON по согласованной схеме.",
+                    }
+                )
+
+        raise ValueError("Модель не вернула корректный JSON")
+
+
+__all__ = ["RecipeLLM", "Recipe", "Nutrition"]


### PR DESCRIPTION
## Summary
- add RecipeLLM client using DeepSeek chat completions
- parse model output with JSON schema and pydantic validation

## Testing
- `ruff check llm_client.py`
- `black llm_client.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68988c7a9c088329845932cb93f7bdd5