### PR TITLE
feat: add recipe dialog and OpenAI client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,5 @@
 
 TELEGRAM_TOKEN=
 
-# API-ключ DeepSeek
-DEEPSEEK_API_KEY=
+# API-ключ OpenAI
+OPENAI_API_KEY=

--- a/bot.py
+++ b/bot.py
@@ -1,52 +1,114 @@
-"""Простой Telegram-бот для генерации рецептов."""
+"""Telegram-бот для генерации рецептов."""
 
 import logging
 import os
 
-
 from dotenv import load_dotenv
-
-from telegram import Update
+from telegram import ReplyKeyboardMarkup, ReplyKeyboardRemove, Update
 from telegram.ext import (
-    ApplicationBuilder,
+    Application,
     CommandHandler,
     ContextTypes,
+    ConversationHandler,
     MessageHandler,
     filters,
 )
 
-from llm_client import generate_recipe
+from formatters import format_recipe
+from llm_client import RecipeLLM, RecipeLLMError
+
 
 load_dotenv()  # загрузка переменных окружения из .env
+
 
 logging.basicConfig(level=logging.INFO)  # настройка логирования
 
 
+INGREDIENTS, MOOD = range(2)
+
+
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Приветственное сообщение для пользователя."""
+    """Приветствие и краткая инструкция."""
+
     await update.message.reply_text(
-        "Отправьте список ингредиентов, и я предложу подходящий рецепт."
+        "Привет! Используйте /recipe, чтобы получить рецепт "
+        "по ингредиентам и настроению."
     )
 
 
-async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Обрабатывает список ингредиентов и отвечает рецептом."""
-    ingredients = update.message.text
-    recipe = generate_recipe(ingredients)
-    await update.message.reply_text(recipe)
+async def recipe_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Первый шаг диалога: запрос ингредиентов."""
+
+    await update.message.reply_text("Введите ингредиенты через запятую:")
+    return INGREDIENTS
+
+
+async def receive_ingredients(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> int:
+    """Сохраняет ингредиенты и спрашивает настроение."""
+
+    context.user_data["ingredients"] = update.message.text
+    keyboard = [["simple", "fancy"]]
+    await update.message.reply_text(
+        "Выберите настроение:",
+        reply_markup=ReplyKeyboardMarkup(
+            keyboard, one_time_keyboard=True, resize_keyboard=True
+        ),
+    )
+    return MOOD
+
+
+async def receive_mood(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Вызывает LLM и отправляет результат пользователю."""
+
+    ingredients = context.user_data.get("ingredients", "")
+    mood = update.message.text.strip()
+
+    try:
+        recipe = RecipeLLM.generate(ingredients, mood)
+        message = format_recipe(recipe)
+        await update.message.reply_text(
+            message, parse_mode="Markdown", reply_markup=ReplyKeyboardRemove()
+        )
+    except RecipeLLMError as exc:
+        await update.message.reply_text(
+            f"Не удалось получить рецепт: {exc}", reply_markup=ReplyKeyboardRemove()
+        )
+
+    context.user_data.clear()
+    return ConversationHandler.END
+
+
+async def cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Позволяет прервать диалог."""
+
+    context.user_data.clear()
+    await update.message.reply_text(
+        "Диалог прерван.", reply_markup=ReplyKeyboardRemove()
+    )
+    return ConversationHandler.END
 
 
 def main() -> None:
     """Запускает приложение и регистрирует обработчики."""
 
     token = os.environ["TELEGRAM_TOKEN"]
+    application = Application.builder().token(token).build()
 
-    application = ApplicationBuilder().token(token).build()
+    conv_handler = ConversationHandler(
+        entry_points=[CommandHandler("recipe", recipe_start)],
+        states={
+            INGREDIENTS: [
+                MessageHandler(filters.TEXT & ~filters.COMMAND, receive_ingredients)
+            ],
+            MOOD: [MessageHandler(filters.TEXT & ~filters.COMMAND, receive_mood)],
+        },
+        fallbacks=[CommandHandler("cancel", cancel)],
+    )
 
     application.add_handler(CommandHandler("start", start))
-    application.add_handler(
-        MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message)
-    )
+    application.add_handler(conv_handler)
 
     application.run_polling()
 

--- a/formatters.py
+++ b/formatters.py
@@ -1,0 +1,38 @@
+"""Форматирование рецептов для отправки пользователю."""
+
+from telegram.helpers import escape_markdown
+
+from llm_client import Recipe
+
+
+def format_recipe(recipe: Recipe) -> str:
+    """Превращает объект рецепта в Markdown-строку."""
+
+    lines: list[str] = []
+
+    lines.append(f"*{escape_markdown(recipe.name, version=1)}*")
+    lines.append("")
+    lines.append("*Ингредиенты:*")
+    for item in recipe.ingredients:
+        lines.append(f"- {escape_markdown(item, version=1)}")
+
+    lines.append("")
+    lines.append("*Шаги:*")
+    for idx, step in enumerate(recipe.steps, 1):
+        lines.append(f"{idx}. {escape_markdown(step, version=1)}")
+
+    lines.append("")
+    lines.append("*КБЖУ:*")
+    lines.append("| Ккал | Белки г | Жиры г | Углеводы г |")
+    lines.append("| --- | --- | --- | --- |")
+    n = recipe.nutrition
+    lines.append(f"| {n.calories} | {n.protein} | {n.fat} | {n.carbs} |")
+
+    lines.append(f"Холестерин: {recipe.cholesterol_mg} мг; ГИ: {recipe.glycemic_index}")
+    if recipe.approx:
+        lines.append("_значения приблизительные_")
+
+    return "\n".join(lines)
+
+
+__all__ = ["format_recipe"]

--- a/llm_client.py
+++ b/llm_client.py
@@ -1,15 +1,15 @@
 """Обёртка для обращения к LLM и генерации рецептов."""
 
-
 from pathlib import Path
-
+from typing import List
 
 from dotenv import load_dotenv
-from deepseek import DeepSeekAPI
+from openai import OpenAI
+from openai.error import OpenAIError, RateLimitError
+from pydantic import BaseModel, ValidationError
 
 
 load_dotenv()  # загрузка переменных окружения из .env
-
 
 
 def _load_prompt(name: str) -> str:
@@ -21,18 +21,77 @@ def _load_prompt(name: str) -> str:
 SYSTEM_PROMPT = _load_prompt("recipe_system.md")
 USER_TEMPLATE = _load_prompt("recipe_user_template.md")
 
-
-_client = DeepSeekAPI()  # инициализация клиента с API-ключом из окружения
-
+_client = OpenAI()  # инициализация клиента с API-ключом из окружения
 
 
-def generate_recipe(ingredients: str) -> str:
-    """Формирует рецепт на основе списка ингредиентов."""
-    prompt = USER_TEMPLATE.format(ingredients=ingredients)
-    response = _client.chat_completion(
+class Nutrition(BaseModel):
+    """Модель данных для блока КБЖУ."""
 
-        prompt=prompt,
-        prompt_sys=SYSTEM_PROMPT,
+    calories: int
+    protein: float
+    fat: float
+    carbs: float
 
-    )
-    return response.strip()
+
+class Recipe(BaseModel):
+    """Модель итогового рецепта."""
+
+    name: str
+    ingredients: List[str]
+    steps: List[str]
+    nutrition: Nutrition
+    cholesterol_mg: int
+    glycemic_index: int
+    approx: bool | None = None
+
+
+class RecipeLLMError(Exception):
+    """Базовая ошибка генерации рецепта."""
+
+
+class RecipeLLM:
+    """Клиент генерации рецептов через LLM."""
+
+    @staticmethod
+    def generate(ingredients: str, mood: str) -> Recipe:
+        """Вызывает модель и возвращает валидированный рецепт."""
+
+        prompt = USER_TEMPLATE.replace("{{ingredients_csv}}", ingredients).replace(
+            "{{mood}}", mood
+        )
+
+        messages = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": prompt},
+        ]
+
+        for attempt in range(2):
+            try:
+                response = _client.chat.completions.create(
+                    model="gpt-4o-mini",
+                    messages=messages,
+                )
+            except (RateLimitError, OpenAIError) as exc:
+                raise RecipeLLMError("Сервис недоступен, попробуйте позже") from exc
+
+            content = response.choices[0].message.content.strip()
+
+            try:
+                return Recipe.model_validate_json(content)
+            except ValidationError:
+                if attempt == 0:
+                    messages.append({"role": "assistant", "content": content})
+                    messages.append(
+                        {
+                            "role": "user",
+                            "content": "Ответ не в формате JSON. "
+                            "Верни только корректный JSON по схеме.",
+                        }
+                    )
+                    continue
+                raise RecipeLLMError("Модель вернула некорректный ответ")
+
+        raise RecipeLLMError("Модель вернула некорректный ответ")
+
+
+__all__ = ["RecipeLLM", "Recipe", "RecipeLLMError"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10"
 dependencies = [
     "python-telegram-bot>=21.0.0",
 
-    "deepseek>=1.0.0",
+    "openai>=1.0.0",
     "python-dotenv>=1.0.0",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python-telegram-bot>=21.0.0
 
-deepseek>=1.0.0
+openai>=1.0.0
 python-dotenv>=1.0.0
 pydantic>=2.0  # optional: валидация ответа модели
 


### PR DESCRIPTION
## Summary
- implement two-step /recipe dialog with mood selection and formatted output
- add OpenAI-based RecipeLLM with JSON validation and retry
- add Markdown formatter and switch project to OpenAI SDK

## Testing
- `black .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_b_6898952822188329902f8febeb2eda08