### PR TITLE
feat: add recipe model and markdown formatter

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -14,7 +14,7 @@ from telegram.ext import (
     filters,
 )
 
-from formatters import format_recipe
+from formatters import format_markdown
 from llm_client import RecipeLLM, RecipeLLMError
 
 
@@ -67,7 +67,7 @@ async def receive_mood(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
 
     try:
         recipe = RecipeLLM.generate(ingredients, mood)
-        message = format_recipe(recipe)
+        message = format_markdown(recipe)
         await update.message.reply_text(
             message, parse_mode="Markdown", reply_markup=ReplyKeyboardRemove()
         )

--- a/formatters.py
+++ b/formatters.py
@@ -5,9 +5,10 @@ from telegram.helpers import escape_markdown
 from llm_client import Recipe
 
 
-def format_recipe(recipe: Recipe) -> str:
+def format_markdown(data: Recipe) -> str:
     """Превращает объект рецепта в Markdown-строку."""
 
+    recipe = data
     lines: list[str] = []
 
     lines.append(f"*{escape_markdown(recipe.name, version=1)}*")
@@ -35,4 +36,4 @@ def format_recipe(recipe: Recipe) -> str:
     return "\n".join(lines)
 
 
-__all__ = ["format_recipe"]
+__all__ = ["format_markdown"]

--- a/llm_client.py
+++ b/llm_client.py
@@ -1,12 +1,11 @@
 """Обёртка для обращения к LLM и генерации рецептов."""
 
 from pathlib import Path
-from typing import List
 
 from dotenv import load_dotenv
 from openai import OpenAI
 from openai.error import OpenAIError, RateLimitError
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, ConfigDict, ValidationError
 
 
 load_dotenv()  # загрузка переменных окружения из .env
@@ -32,17 +31,21 @@ class Nutrition(BaseModel):
     fat: float
     carbs: float
 
+    model_config = ConfigDict(extra="forbid")
+
 
 class Recipe(BaseModel):
     """Модель итогового рецепта."""
 
     name: str
-    ingredients: List[str]
-    steps: List[str]
+    ingredients: list[str]
+    steps: list[str]
     nutrition: Nutrition
     cholesterol_mg: int
     glycemic_index: int
     approx: bool | None = None
+
+    model_config = ConfigDict(extra="forbid")
 
 
 class RecipeLLMError(Exception):


### PR DESCRIPTION
## Summary
- add pydantic Recipe model with strict schema
- format recipe JSON into Telegram Markdown
- use new formatter when sending responses

## Testing
- `make format`
- `make lint`
- `python -m py_compile bot.py llm_client.py formatters.py`


------
https://chatgpt.com/codex/tasks/task_b_68989741aacc8329a8ef787d53994048