### PR TITLE
chore: expand Dockerfile for build deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,18 @@
 FROM python:3.12-slim
 WORKDIR /app
 
+# Чтоб логи сразу выводились и не забивался кеш pip
+ENV PYTHONUNBUFFERED=1 PYTHONIOENCODING=utf-8 PIP_NO_CACHE_DIR=1
+
+# Иногда нужны базовые инструменты сборки для зависимостей
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential curl ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
-ENV PYTHONUNBUFFERED=1 PYTHONIOENCODING=utf-8
 
-# Бот запускается как фон-процесс (long polling), веб-порт не нужен
+# Никаких портов — это long polling
 CMD ["python", "bot.py"]


### PR DESCRIPTION
## Summary
- install build tools and curl/ca-certificates for dependency compilation
- ensure pip doesn't cache packages and enable immediate log flushing

## Testing
- `make format`
- `make lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b7dd0990ec8329a25b3084daacc814