### PR TITLE
Add unit tests for recipe generation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,13 @@ requires-python = ">=3.10"
 dependencies = [
     "python-telegram-bot>=21.0.0",
 
-    "openai>=1.0.0",
+    "deepseek>=1.0.0",
     "python-dotenv>=1.0.0",
 ]
 
 [project.optional-dependencies]
 validation = ["pydantic>=2.0"]
-dev = ["black>=23.0", "ruff>=0.0.289"]
+dev = ["black>=23.0", "ruff>=0.0.289", "pytest>=7.0"]
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Общие настройки тестов."""
+
+import os
+import sys
+from pathlib import Path
+
+# Подставляем API-ключ для клиента DeepSeek
+os.environ.setdefault("DEEPSEEK_API_KEY", "test")
+
+# Добавляем корень репозитория в sys.path для импорта модулей
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,0 +1,24 @@
+"""Тесты для функции format_markdown."""
+
+from llm_client import Nutrition, Recipe
+from formatters import format_markdown
+
+
+def test_format_markdown_basic() -> None:
+    """Проверяет корректность Markdown-формата."""
+    recipe = Recipe(
+        name="Омлет",
+        ingredients=["яйцо", "молоко"],
+        steps=["Смешать", "Жарить"],
+        nutrition=Nutrition(calories=100, protein=10, fat=5, carbs=1),
+        cholesterol_mg=200,
+        glycemic_index=50,
+    )
+
+    result = format_markdown(recipe)
+
+    assert "*Омлет*" in result
+    assert "- яйцо" in result
+    assert "1. Смешать" in result
+    assert "| 100 | 10.0 | 5.0 | 1.0 |" in result
+    assert "Холестерин: 200 мг" in result

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,49 @@
+"""Тесты для клиента генерации рецептов."""
+
+import json
+import pytest
+
+import llm_client
+from llm_client import RecipeLLM, RecipeLLMError
+
+
+class DummyClient:
+    """Заглушка клиента DeepSeek."""
+
+    def __init__(self, responses: list[str]) -> None:
+        self.responses = responses
+        self.index = 0
+
+    def chat_completion(self, *args, **kwargs):
+        content = self.responses[self.index]
+        self.index += 1
+        return content
+
+
+def test_generate_valid_json(monkeypatch) -> None:
+    """Успешная генерация рецепта при корректном JSON."""
+    response = json.dumps(
+        {
+            "name": "Суп",
+            "ingredients": ["вода"],
+            "steps": ["Налить воду"],
+            "nutrition": {
+                "calories": 1,
+                "protein": 0.1,
+                "fat": 0.0,
+                "carbs": 0.2,
+            },
+            "cholesterol_mg": 0,
+            "glycemic_index": 5,
+        }
+    )
+    monkeypatch.setattr(llm_client, "_client", DummyClient([response]))
+    recipe = RecipeLLM.generate("вода", "simple")
+    assert recipe.name == "Суп"
+
+
+def test_generate_invalid_json(monkeypatch) -> None:
+    """Ошибка при двух некорректных ответах модели."""
+    monkeypatch.setattr(llm_client, "_client", DummyClient(["bad", "still bad"]))
+    with pytest.raises(RecipeLLMError):
+        RecipeLLM.generate("вода", "simple")


### PR DESCRIPTION
## Summary
- add pytest to dev dependencies
- cover recipe formatting with pytest
- test RecipeLLM JSON handling with mocked DeepSeek client
- switch LLM client to DeepSeek API

## Testing
- `black .`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b7dde033a48329b12572831bbad749