### PR TITLE
chore: replace openai dependency with deepseek

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python-telegram-bot>=21.0.0
 
-openai>=1.0.0
+deepseek>=1.0.0
 python-dotenv>=1.0.0
 pydantic>=2.0  # optional: валидация ответа модели
 


### PR DESCRIPTION
### Что сделано
- Заменена зависимость openai на deepseek>=1.0.0 в `requirements.txt`
- Версия синхронизирована с `pyproject.toml`

### Зачем
- Удаляем неиспользуемый openai и используем deepseek как поставщика LLM

### Как проверить
- `black .`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b7e233c1a88329a96f2f0b90f49047